### PR TITLE
refactor(bot-discord): Auto side-effects

### DIFF
--- a/apps/bot-discord/package.json
+++ b/apps/bot-discord/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@hono/node-server": "^0.6.0",
     "discord.js": "^14.9.0",
+    "fast-glob": "^3.2.12",
     "hono": "^3.1.7",
     "node-cron": "^3.0.2",
     "zod": "^3.21.4"

--- a/apps/bot-discord/src/index.ts
+++ b/apps/bot-discord/src/index.ts
@@ -4,7 +4,7 @@ import { serveStatic } from "@hono/node-server/serve-static"
 import { Client, Partials, GatewayIntentBits } from "discord.js"
 
 import { env } from "~/lib/env"
-import { getCore } from "~/lib/core"
+import { getRegistrations } from "~/lib/core"
 
 const app = new Hono()
 
@@ -24,9 +24,9 @@ const bot = new Client({
 
 bot.once("ready", () => console.log("🚀"))
 
-const core = await getCore()
+const registrations = await getRegistrations()
 
-core.handlers.forEach((callbacks, event) => {
+registrations.handlers.forEach((callbacks, event) => {
   bot.addListener(event, (...args) => callbacks.forEach((callback) => callback(...args)))
 })
 

--- a/apps/bot-discord/src/index.ts
+++ b/apps/bot-discord/src/index.ts
@@ -4,15 +4,7 @@ import { serveStatic } from "@hono/node-server/serve-static"
 import { Client, Partials, GatewayIntentBits } from "discord.js"
 
 import { env } from "~/lib/env"
-import { handlersMap } from "~/lib/core"
-
-import "~/app/errors"
-import "~/app/avatar"
-import "~/app/live-role"
-import "~/app/admin/command"
-import "~/app/role-reactions/friend"
-import "~/app/role-reactions/pronouns"
-import "~/app/role-reactions/region"
+import { getCore } from "~/lib/core"
 
 const app = new Hono()
 
@@ -32,7 +24,9 @@ const bot = new Client({
 
 bot.once("ready", () => console.log("🚀"))
 
-handlersMap.forEach((callbacks, event) => {
+const core = await getCore()
+
+core.handlers.forEach((callbacks, event) => {
   bot.addListener(event, (...args) => callbacks.forEach((callback) => callback(...args)))
 })
 

--- a/apps/bot-discord/src/lib/core.ts
+++ b/apps/bot-discord/src/lib/core.ts
@@ -32,11 +32,11 @@ export function registerSlashCommand<T extends CommandBuilderStub>(
   })
 }
 
-export async function getCore() {
+export async function getRegistrations() {
   const files = await glob("src/app/**/*.ts")
   const imports = files.map((file) => import(`../app/${file.replace("src/app", "")}`))
 
-  // Lets side-effects run
+  // Let side-effects run
   await Promise.all(imports)
 
   return {

--- a/apps/bot-discord/src/lib/core.ts
+++ b/apps/bot-discord/src/lib/core.ts
@@ -1,8 +1,9 @@
 import type { ClientEvents, SlashCommandBuilder } from "discord.js"
+import glob from "fast-glob"
 
 type RegisterEventCallback<T extends keyof ClientEvents> = (...args: ClientEvents[T]) => void
 
-export const handlersMap = new Map<keyof ClientEvents, Set<RegisterEventCallback<any>>>()
+const handlersMap = new Map<keyof ClientEvents, Set<RegisterEventCallback<any>>>()
 
 export function registerEventHandler<T extends keyof ClientEvents>(event: T, callback: RegisterEventCallback<T>) {
   const set = handlersMap.get(event) ?? new Set<RegisterEventCallback<T>>()
@@ -12,7 +13,7 @@ export function registerEventHandler<T extends keyof ClientEvents>(event: T, cal
 
 type CommandBuilderStub = Pick<SlashCommandBuilder, "name" | "toJSON">
 
-export const slashCommandsMap = new Map<string, CommandBuilderStub>()
+const slashCommandsMap = new Map<string, CommandBuilderStub>()
 
 export function registerSlashCommand<T extends CommandBuilderStub>(
   builder: T,
@@ -29,4 +30,17 @@ export function registerSlashCommand<T extends CommandBuilderStub>(
     if (interaction.commandName !== builder.name) return
     callback(interaction)
   })
+}
+
+export async function getCore() {
+  const files = await glob("src/app/**/*.ts")
+  const imports = files.map((file) => import(`../app/${file.replace("src/app", "")}`))
+
+  // Lets side-effects run
+  await Promise.all(imports)
+
+  return {
+    handlers: handlersMap,
+    slashCommands: slashCommandsMap,
+  }
 }

--- a/apps/bot-discord/src/scripts/sync.ts
+++ b/apps/bot-discord/src/scripts/sync.ts
@@ -1,12 +1,12 @@
 import { REST, Routes } from "discord.js"
 
 import { env } from "~/lib/env"
-import { getCore } from "~/lib/core"
+import { getRegistrations } from "~/lib/core"
 import { APPLICATION_ID, SERVER_ID } from "~/lib/constants"
 
-const core = await getCore()
+const registrations = await getRegistrations()
 const rest = new REST({ version: "10" }).setToken(env.DISCORD_BOT_TOKEN)
-const body = Array.from(core.slashCommands.values()).map((value) => value.toJSON())
+const body = Array.from(registrations.slashCommands.values()).map((value) => value.toJSON())
 
 try {
   await rest.put(Routes.applicationGuildCommands(APPLICATION_ID, SERVER_ID), {

--- a/apps/bot-discord/src/scripts/sync.ts
+++ b/apps/bot-discord/src/scripts/sync.ts
@@ -1,19 +1,12 @@
 import { REST, Routes } from "discord.js"
 
 import { env } from "~/lib/env"
-import { slashCommandsMap } from "~/lib/core"
+import { getCore } from "~/lib/core"
 import { APPLICATION_ID, SERVER_ID } from "~/lib/constants"
 
-import "~/app/errors"
-import "~/app/avatar"
-import "~/app/live-role"
-import "~/app/admin/command"
-import "~/app/role-reactions/friend"
-import "~/app/role-reactions/pronouns"
-import "~/app/role-reactions/region"
-
+const core = await getCore()
 const rest = new REST({ version: "10" }).setToken(env.DISCORD_BOT_TOKEN)
-const body = Array.from(slashCommandsMap.values()).map((value) => value.toJSON())
+const body = Array.from(core.slashCommands.values()).map((value) => value.toJSON())
 
 try {
   await rest.put(Routes.applicationGuildCommands(APPLICATION_ID, SERVER_ID), {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,9 @@ importers:
       discord.js:
         specifier: ^14.9.0
         version: 14.9.0
+      fast-glob:
+        specifier: ^3.2.12
+        version: 3.2.12
       hono:
         specifier: ^3.1.7
         version: 3.1.7
@@ -308,6 +311,27 @@ packages:
       '@remix-run/web-stream': 1.0.3
     dev: false
 
+  /@nodelib/fs.scandir@2.1.5:
+    resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
+    engines: {node: '>= 8'}
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      run-parallel: 1.2.0
+    dev: false
+
+  /@nodelib/fs.stat@2.0.5:
+    resolution: {integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==}
+    engines: {node: '>= 8'}
+    dev: false
+
+  /@nodelib/fs.walk@1.2.8:
+    resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
+    engines: {node: '>= 8'}
+    dependencies:
+      '@nodelib/fs.scandir': 2.1.5
+      fastq: 1.15.0
+    dev: false
+
   /@remix-run/web-blob@3.0.4:
     resolution: {integrity: sha512-AfegzZvSSDc+LwnXV+SwROTrDtoLiPxeFW+jxgvtDAnkuCX1rrzmVJ6CzqZ1Ai0bVfmJadkG5GxtAfYclpPmgw==}
     dependencies:
@@ -404,6 +428,13 @@ packages:
     engines: {node: '>= 0.4'}
     dev: false
 
+  /braces@3.0.2:
+    resolution: {integrity: sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==}
+    engines: {node: '>=8'}
+    dependencies:
+      fill-range: 7.0.1
+    dev: false
+
   /buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
     dev: true
@@ -497,6 +528,23 @@ packages:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
     dev: false
 
+  /fast-glob@3.2.12:
+    resolution: {integrity: sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==}
+    engines: {node: '>=8.6.0'}
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      '@nodelib/fs.walk': 1.2.8
+      glob-parent: 5.1.2
+      merge2: 1.4.1
+      micromatch: 4.0.5
+    dev: false
+
+  /fastq@1.15.0:
+    resolution: {integrity: sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==}
+    dependencies:
+      reusify: 1.0.4
+    dev: false
+
   /file-type@18.2.1:
     resolution: {integrity: sha512-Yw5MtnMv7vgD2/6Bjmmuegc8bQEVA9GmAyaR18bMYWKqsWDG9wgYZ1j4I6gNMF5Y5JBDcUcjRQqNQx7Y8uotcg==}
     engines: {node: '>=14.16'}
@@ -504,6 +552,13 @@ packages:
       readable-web-to-node-stream: 3.0.2
       strtok3: 7.0.0
       token-types: 5.0.1
+    dev: false
+
+  /fill-range@7.0.1:
+    resolution: {integrity: sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==}
+    engines: {node: '>=8'}
+    dependencies:
+      to-regex-range: 5.0.1
     dev: false
 
   /for-each@0.3.3:
@@ -535,6 +590,13 @@ packages:
   /get-tsconfig@4.5.0:
     resolution: {integrity: sha512-MjhiaIWCJ1sAU4pIQ5i5OfOuHHxVo1oYeNsWTON7jxYkod8pHocXeh+SSbmu5OZZZK73B6cbJ2XADzXehLyovQ==}
     dev: true
+
+  /glob-parent@5.1.2:
+    resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
+    engines: {node: '>= 6'}
+    dependencies:
+      is-glob: 4.0.3
+    dev: false
 
   /gopd@1.0.1:
     resolution: {integrity: sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==}
@@ -587,11 +649,28 @@ packages:
     engines: {node: '>= 0.4'}
     dev: false
 
+  /is-extglob@2.1.1:
+    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
+    engines: {node: '>=0.10.0'}
+    dev: false
+
   /is-generator-function@1.0.10:
     resolution: {integrity: sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==}
     engines: {node: '>= 0.4'}
     dependencies:
       has-tostringtag: 1.0.0
+    dev: false
+
+  /is-glob@4.0.3:
+    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      is-extglob: 2.1.1
+    dev: false
+
+  /is-number@7.0.0:
+    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
+    engines: {node: '>=0.12.0'}
     dev: false
 
   /is-typed-array@1.1.10:
@@ -613,6 +692,19 @@ packages:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
     dev: false
 
+  /merge2@1.4.1:
+    resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
+    engines: {node: '>= 8'}
+    dev: false
+
+  /micromatch@4.0.5:
+    resolution: {integrity: sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==}
+    engines: {node: '>=8.6'}
+    dependencies:
+      braces: 3.0.2
+      picomatch: 2.3.1
+    dev: false
+
   /mrmime@1.0.1:
     resolution: {integrity: sha512-hzzEagAgDyoU1Q6yg5uI+AorQgdvMCur3FcKf7NhMKWsaYg+RnbTyHRa/9IlLF9rf455MOCtcqqrQQ83pPP7Uw==}
     engines: {node: '>=10'}
@@ -630,6 +722,15 @@ packages:
     engines: {node: '>=14.16'}
     dev: false
 
+  /picomatch@2.3.1:
+    resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
+    engines: {node: '>=8.6'}
+    dev: false
+
+  /queue-microtask@1.2.3:
+    resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+    dev: false
+
   /readable-stream@3.6.2:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
     engines: {node: '>= 6'}
@@ -644,6 +745,17 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       readable-stream: 3.6.2
+    dev: false
+
+  /reusify@1.0.4:
+    resolution: {integrity: sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==}
+    engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+    dev: false
+
+  /run-parallel@1.2.0:
+    resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+    dependencies:
+      queue-microtask: 1.2.3
     dev: false
 
   /safe-buffer@5.2.1:
@@ -679,6 +791,13 @@ packages:
     dependencies:
       '@tokenizer/token': 0.3.0
       peek-readable: 5.0.0
+    dev: false
+
+  /to-regex-range@5.0.1:
+    resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
+    engines: {node: '>=8.0'}
+    dependencies:
+      is-number: 7.0.0
     dev: false
 
   /token-types@5.0.1:


### PR DESCRIPTION
# The problem

The bot callback system relies on side-effects in order to make the development of features more straightforward. The idea is that you should be able to call `registerEventHandler` or `registerSlashCommand` anywhere inside the `app` directory and it should just work. Currently this relies on side-effects. Because we are just calling a function, files that aren't imported in the root `index.ts` don't get to run their side-effects. 

## The current solution

Currently and just to get by, we're importing every file that calls `registerEventHandler` or `registerSlashCommand` on `index.ts`, and every file that calls `registerSlashCommand` on `scripts/sync.ts`. This kinda defeats the purpose.

## The proposed solutions

### Special, barrel export files

Add some kind of `features` folder, where every file that calls `registerEventHandler` or `registerSlashCommand` should get imported in a barrel export `features/index.ts`file.

This makes the dx clunky and I don't particularly like it

### Naming conventions

Files that are named `*.effect.ts` or something like that get automagically `import()`ed when running the app, letting them run their side-effects.

This is better but the naming convention thingie is kind of opaque

### Auto-importing everything

Instead of introducing a file naming convention, just `import()` every file inside `app` and call it a day. It might not be the best solution in terms of performance but it only runs once on initialization and I really like the ergonomics it unlocks. You **just** `register` callbacks, anywhere. It's kinda cool

This pr adds this last method