### PR TITLE
feat(db): keep database alive

### DIFF
--- a/apps/bot-discord/src/app/keep-db-alive.ts
+++ b/apps/bot-discord/src/app/keep-db-alive.ts
@@ -1,0 +1,15 @@
+import { connect, keepAliveDummies } from "db"
+import { registerEventHandler } from "~/lib/core"
+import { cron } from "~/lib/helpers"
+
+/**
+ * PlanetScale deactivates databases without activity.
+ * We write daily to this table to prevent deactivation
+ */
+registerEventHandler("ready", () => {
+  cron("0 0 * * *", async () => {
+    const db = connect()
+    await db.insert(keepAliveDummies).values({})
+    await db.delete(keepAliveDummies)
+  })
+})

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -1,4 +1,13 @@
-import { mysqlTable, int, serial, timestamp, char, tinyint, varchar } from "drizzle-orm/mysql-core"
+import { mysqlTable, serial, timestamp, char, tinyint, varchar } from "drizzle-orm/mysql-core"
+
+/**
+ * PlanetScale deactivates databases without activity.
+ * In the Discord bot deployment we write daily to this table
+ * to prevent deactivation
+ */
+export const keepAliveDummies = mysqlTable("keep_alive_dummies", {
+  id: serial("id").primaryKey(),
+})
 
 export const discordPolls = mysqlTable("discord_polls", {
   id: char("id", { length: 21 }).notNull().primaryKey(),


### PR DESCRIPTION
PlanetScale deactivates free tier databases when no writes are made in a period of time. With this PR, we're adding a cron job to the discord deployment to write and then delete to the db once every day